### PR TITLE
add loader for the arrivals board

### DIFF
--- a/src/components/Arrivals/ArrivalsBoard.js
+++ b/src/components/Arrivals/ArrivalsBoard.js
@@ -3,6 +3,7 @@ import StationHeader from './StationHeader';
 import Client from '../../Client';
 import Lines from '../../parsers/lines';
 import TrainListContainer from './TrainListContainer';
+import CircularProgress from 'material-ui/CircularProgress';
 
 class ArrivalsBoard extends Component {
   constructor(props){
@@ -14,7 +15,8 @@ class ArrivalsBoard extends Component {
       outboundArrivals: [],
       outboundName: "outbound",
       stationName: "",
-      lineName: ""
+      lineName: "",
+      isLoading: true
     }
   }
 
@@ -29,12 +31,19 @@ class ArrivalsBoard extends Component {
         outboundArrivals: data.arrivals.outbound.trains,
         outboundName: data.arrivals.outbound.name,
         stationName: data.station_name,
-        lineName: Lines.prettify(data.line_id)
+        lineName: Lines.prettify(data.line_id),
+        isLoading: false
       })
     })
   }
+
   render(){
+    var loader =
+      <div className="loader-wrapper">
+        <CircularProgress size={80} thickness={7}/>
+      </div>
     return(
+      this.state.isLoading ? loader :
       <div>
         <StationHeader
           stationName={this.state.stationName}

--- a/src/components/Arrivals/styles.css
+++ b/src/components/Arrivals/styles.css
@@ -59,3 +59,11 @@
   font-size: 1em;
   padding: 0;
 }
+
+.loader-wrapper {
+  height: 100%;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}


### PR DESCRIPTION
This is a really basic implementation of a loader to avoid a blank page while we grab the arrivals data from TFL.